### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ master ]


### PR DESCRIPTION
Potential fix for [https://github.com/RumenDamyanov/php-sitemap/security/code-scanning/1](https://github.com/RumenDamyanov/php-sitemap/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow file, specifying the least privilege required for the workflow to function. The best way to do this is to add the `permissions` key at the root level of the workflow (before `jobs:`), so it applies to all jobs unless overridden. For most CI workflows, `contents: read` is sufficient, unless a step requires additional permissions (e.g., creating pull requests, writing to issues, etc.). In this workflow, none of the steps appear to require write access, so `contents: read` is appropriate. You should insert the following block after the workflow `name` and before the `on:` block:

```yaml
permissions:
  contents: read
```

No additional imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
